### PR TITLE
Fixed boundary type testing

### DIFF
--- a/src/SingleDayTime/SingleDayTimeInterval.php
+++ b/src/SingleDayTime/SingleDayTimeInterval.php
@@ -190,7 +190,7 @@ final class SingleDayTimeInterval extends Interval
 	 */
 	private function isEndingAtMidnightNextDay(Boundary $left, Boundary $right): bool
 	{
-		return !($left->isOpened() && $left->getValue()->isEqual($right))
+		return !($left->isOpened() && $left->getValue()->isEqual($right->getValue()))
 			&& $right->isOpened()
 			&& $right->getValue()->isEqual($this->getZeroElement());
 	}

--- a/tests/SingleDayTime/SingleDayTimeIntervalTest.phpt
+++ b/tests/SingleDayTime/SingleDayTimeIntervalTest.phpt
@@ -10,8 +10,12 @@ namespace Achse\Tests\Interval\SingleDayTime;
 
 require __DIR__ . '/../bootstrap.php';
 
+use Achse\Math\Interval\Boundary;
 use Achse\Math\Interval\DateTimeImmutable\DateTimeImmutable;
 use Achse\Math\Interval\DateTimeImmutable\DateTimeImmutableIntervalStringParser as ImmutableParser;
+use Achse\Math\Interval\IntervalRangesInvalidException;
+use Achse\Math\Interval\SingleDayTime\SingleDayTime;
+use Achse\Math\Interval\SingleDayTime\SingleDayTimeBoundary;
 use Achse\Math\Interval\SingleDayTime\SingleDayTimeInterval;
 use Achse\Math\Interval\SingleDayTime\SingleDayTimeIntervalStringParser as Parser;
 use Tester\Assert;
@@ -173,6 +177,29 @@ final class SingleDayTimeIntervalTest extends TestCase
 		$singleDayInterval = SingleDayTimeInterval::fromString('01:02:03', '04:05:06');
 		$dateTimeInterval = $singleDayInterval->toDaTeTimeInterval(new DateTimeImmutable('2015-10-11T20:21:22+02:00'));
 		Assert::equal('[2015-10-11T01:02:03+02:00, 2015-10-11T04:05:06+02:00)', (string) $dateTimeInterval);
+	}
+
+	public function testInvalidRangeTimeInterval()
+	{
+		Assert::exception(
+			function () {
+				new SingleDayTimeInterval(
+					new SingleDayTimeBoundary(SingleDayTime::from('00:10:00'), Boundary::OPENED),
+					new SingleDayTimeBoundary(SingleDayTime::from('00:01:00'), Boundary::OPENED)
+				);
+			},
+			IntervalRangesInvalidException::class
+		);
+	}
+
+	public function testOverMidnightTime()
+	{
+		$dateTimeInterval = new SingleDayTimeInterval(
+			new SingleDayTimeBoundary(SingleDayTime::from('00:10:00'), Boundary::OPENED),
+			new SingleDayTimeBoundary(SingleDayTime::from('00:00:00'), Boundary::OPENED)
+		);
+
+		Assert::equal('(00:10:00, 00:00:00)', (string) $dateTimeInterval);
 	}
 
 }


### PR DESCRIPTION
Fixed boundary type testing - SingleDayTimeInterval ending at midnight next day

this code:
```
new SingleDayTimeInterval(
     new SingleDayTimeBoundary(SingleDayTime::from('00:10:00'), Boundary::OPENED),
     new SingleDayTimeBoundary(SingleDayTime::from('00:00:00'), Boundary::OPENED)
);
```

throws:
```
InvalidArgumentException: Value must be type of Achse\Math\Interval\SingleDayTime\SingleDayTime but Achse\Math\Interval\SingleDayTime\SingleDayTimeBoundary given.
```